### PR TITLE
Update slurm scripts for Iridis 6

### DIFF
--- a/health_data/slurm/generate-maps-furrr-array.slurm
+++ b/health_data/slurm/generate-maps-furrr-array.slurm
@@ -14,10 +14,10 @@
 # send mail to this address
 #SBATCH --mail-user=youremail@here.com
 
-module load gdal/3.0.1
-module load proj/6.1.1
-module load geos/3.6.2
-module load R/4.4.1-gcc
+module load gdal/3.9.2
+module load proj/9.4.1
+module load geos/3.13.0
+module load R/4.4.0-gcc8
 
 cd parallel-r-materials/
 Rscript health_data/generate-maps-furrr.R 1 40

--- a/health_data/slurm/generate-maps-furrr.slurm
+++ b/health_data/slurm/generate-maps-furrr.slurm
@@ -12,10 +12,10 @@
 # send mail to this address
 #SBATCH --mail-user=your.email@here.com
 
-module load gdal/3.0.1
-module load proj/6.1.1
-module load geos/3.6.2
-module load R/4.4.1-gcc
+module load gdal/3.9.2
+module load proj/9.4.1
+module load geos/3.13.0
+module load R/4.4.0-gcc8
 
 cd parallel-r-materials/
 Rscript health_data/generate-maps-furrr.R 1 10

--- a/nba/slurm/nba-playoffs.slurm
+++ b/nba/slurm/nba-playoffs.slurm
@@ -13,8 +13,8 @@
 # send mail to this address
 #SBATCH --mail-user=youremail@here.com
 
-module load R/4.4.1-gcc
-module load openmpi/5.0.0/gcc
+module load R/4.4.0-gcc8
+module load openmpi/5.0.9_gcc15
 
 cd parallel-r-materials/
 Rscript nba/nba-playoffs-slurm.R


### PR DESCRIPTION
## Summary
- Update module versions in all slurm scripts to match Iridis 6 availability
- gdal 3.0.1 → 3.9.2, proj 6.1.1 → 9.4.1, geos 3.6.2 → 3.13.0
- R/4.4.1-gcc → R/4.4.0-gcc8
- openmpi/5.0.0/gcc → openmpi/5.0.9_gcc15