### PR TITLE
Fix SLURM scripts to use --cpus-per-task

### DIFF
--- a/health_data/slurm/generate-maps-furrr-array.slurm
+++ b/health_data/slurm/generate-maps-furrr-array.slurm
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #SBATCH --nodes=1
-#SBATCH --ntasks=10
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=10
 #SBATCH --mem=3G
 #SBATCH --job-name=map_furrr_array
 #SBATCH --time=00:05:00

--- a/health_data/slurm/generate-maps-furrr.slurm
+++ b/health_data/slurm/generate-maps-furrr.slurm
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #SBATCH --nodes=1
-#SBATCH --ntasks=10
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=10
 #SBATCH --mem=3G
 #SBATCH --job-name=map_furrr
 #SBATCH --time=00:05:00


### PR DESCRIPTION
## Summary
- Change from --ntasks=10 to --ntasks=1 --cpus-per-task=10 in health data slurm scripts
- future::availableCores() reads SLURM_CPUS_PER_TASK to determine worker count, so this is the correct way to request cores for futureverse parallelism