### PR TITLE
Upgrade R module and refactor conf label formatting

### DIFF
--- a/health_data/R/map-function.R
+++ b/health_data/R/map-function.R
@@ -34,7 +34,12 @@ plot_lad_map <- function(plot_data, out_dir) {
       legend.text = element_text(size = 6),
       legend.title = element_text(size = 10),
       strip.background = element_rect(fill = "white", colour = "white"),
-      strip.text.x = element_text(colour = "gray40", face = "bold", size = 10, hjust = 0)
+      strip.text.x = element_text(
+        colour = "gray40",
+        face = "bold",
+        size = 10,
+        hjust = 0
+      )
     )
 
   # Create deviation from national mean percentage occurrence (z-score) facet plot maps
@@ -56,9 +61,13 @@ plot_lad_map <- function(plot_data, out_dir) {
       legend.text = element_text(size = 6),
       legend.key.height = unit(5, units = "native"),
       strip.background = element_rect(fill = "white", colour = "white"),
-      strip.text.x = element_text(colour = "white", face = "bold", size = 10, hjust = 0)
+      strip.text.x = element_text(
+        colour = "white",
+        face = "bold",
+        size = 10,
+        hjust = 0
+      )
     )
-
 
   # Create map of category of maximum occurrence across each LSOA and scale opacity
   # according to maximum category occurence.
@@ -78,30 +87,48 @@ plot_lad_map <- function(plot_data, out_dir) {
     ) +
     guides(alpha = "none")
 
-
   # Arrange plots
-  plot <- ggarrange(plt_1, plt_2, plot_main,
+  plot <- ggarrange(
+    plt_1,
+    plt_2,
+    plot_main,
     labels = c("A", "B", "C"),
-    ncol = 3, nrow = 1, widths = c(1, 1, 4)
+    ncol = 3,
+    nrow = 1,
+    widths = c(1, 1, 4)
   )
 
   # Add plot annotation
-  plot <- annotate_figure(plot,
-    top = text_grob(glue::glue("General Health Category Data in LDA {unique(plot_data$lad_name)} ({unique(plot_data$lad_code)})"),
+  plot <- annotate_figure(
+    plot,
+    top = text_grob(
+      glue::glue(
+        "General Health Category Data in LDA {unique(plot_data$lad_name)} ({unique(plot_data$lad_code)})"
+      ),
       face = "bold",
       size = 20,
-      just = c("left", "bottom"), x = 0, y = 0
+      just = c("left", "bottom"),
+      x = 0,
+      y = 0
     ),
     bottom = text_grob(
-      paste("A) Percentage occurrence of General health category",
+      paste(
+        "A) Percentage occurrence of General health category",
         "B) Deviation of percentage occurrence from General Health Category National Mean (z-score)",
         "C) Most common health category (opacity reflects percentage occurrence of top category)",
         sep = "\n"
       ),
-      just = c("left", "top"), x = 0.01, y = 0.99, face = "italic", size = 10, lineheight = 1.15
+      just = c("left", "top"),
+      x = 0.01,
+      y = 0.99,
+      face = "italic",
+      size = 10,
+      lineheight = 1.15
     )
   )
-  file_name <- glue::glue("{lad_code}_{janitor::make_clean_names(lad_name)}_{Sys.Date()}.png")
+  file_name <- glue::glue(
+    "{lad_code}_{janitor::make_clean_names(lad_name)}_{Sys.Date()}.png"
+  )
   out_path <- fs::path(file_name, ext = "png")
 
   # Save combined plot
@@ -110,7 +137,9 @@ plot_lad_map <- function(plot_data, out_dir) {
     plot = plot,
     device = "png",
     path = out_dir,
-    width = 29.7, height = 21, units = "cm",
+    width = 29.7,
+    height = 21,
+    units = "cm",
     bg = "white"
   )
 

--- a/health_data/generate-maps-purrr.R
+++ b/health_data/generate-maps-purrr.R
@@ -16,29 +16,30 @@ fs::dir_create(out_dir)
 # Load data ----
 health_data <- readr::read_csv(
   here::here(
-    "health_data", "data",
+    "health_data",
+    "data",
     "lsoa-general_health.csv"
   )
 )
 
 look_up <- readr::read_csv(
   here::here(
-    "health_data", "data",
+    "health_data",
+    "data",
     "output_area_lookup.csv"
   )
 )
 
 boundaries <- read_sf(
   here::here(
-    "health_data", "data",
+    "health_data",
+    "data",
     "lsoa_boundaries.geojson"
   )
 )
 
 # Merge data and validate ----
-all_data <- left_join(health_data, look_up,
-  relationship = "many-to-one"
-) %>%
+all_data <- left_join(health_data, look_up, relationship = "many-to-one") %>%
   left_join(boundaries, relationship = "many-to-one") %>%
   st_as_sf() %>%
   assert(not_na, lsoa_code, lsoa_name, lad_name, lad_code, geometry) %>%
@@ -54,9 +55,9 @@ health_cat_levels <- health_data %>%
 
 # Create addition variables obs_perc & z_score, cast gen_health_cat to factor
 all_data <- all_data %>%
-  mutate(gen_health_cat = factor(gen_health_cat,
-    levels = health_cat_levels
-  )) %>%
+  mutate(
+    gen_health_cat = factor(gen_health_cat, levels = health_cat_levels)
+  ) %>%
   group_by(lsoa_code) %>%
   mutate(obs_perc = observation / sum(observation) * 100) %>%
   ungroup() %>%
@@ -82,4 +83,6 @@ purrr::walk(
 
 cli::cli_h1("Job Complete")
 cli::cli_alert_success("{length(idx)} map{?s} written to {.path {out_dir}}.")
-cli::cli_h2("Total time elapsed: {.val {tictoc::toc(quiet = TRUE)$callback_msg}}")
+cli::cli_h2(
+  "Total time elapsed: {.val {tictoc::toc(quiet = TRUE)$callback_msg}}"
+)

--- a/health_data/slurm/generate-maps-furrr-array.slurm
+++ b/health_data/slurm/generate-maps-furrr-array.slurm
@@ -18,7 +18,7 @@
 module load gdal/3.9.2
 module load proj/9.4.1
 module load geos/3.13.0
-module load R/4.4.0-gcc8
+module load R/4.5.3-gcc8
 
 cd parallel-r-materials/
 Rscript health_data/generate-maps-furrr.R 1 40

--- a/health_data/slurm/generate-maps-furrr.slurm
+++ b/health_data/slurm/generate-maps-furrr.slurm
@@ -16,7 +16,7 @@
 module load gdal/3.9.2
 module load proj/9.4.1
 module load geos/3.13.0
-module load R/4.4.0-gcc8
+module load R/4.5.3-gcc8
 
 cd parallel-r-materials/
 Rscript health_data/generate-maps-furrr.R 1 10

--- a/nba/R/playoff-functions.R
+++ b/nba/R/playoff-functions.R
@@ -45,15 +45,15 @@ play_round <- function(teams, nba_stats, round_name = NULL, seed = TRUE) {
   }
   if (round_name == "Play off Finals") {
     conf <- NA
-    conf_msg <- ""
+    conf_label <- ""
   } else {
     conf <- unique(
       nba_stats[nba_stats$slug_team %in% unlist(teams), ]$id_conference
     )
-    conf_msg <- paste0("(conf ", conf, ") ")
+    conf_label <- format_conf_label(conf)
   }
   # Signal start of round
-  cli::cli_h2("{round_name} {conf_msg}started!")
+  cli::cli_h2("{round_name} {conf_label}started!")
 
   # Create list of round pair match ups
   round_pairs <- draw_match_pairs(unlist(teams))
@@ -74,7 +74,7 @@ play_round <- function(teams, nba_stats, round_name = NULL, seed = TRUE) {
   )
 
   # Signal round completion and return results
-  cli::cli_h2("{round_name} {conf_msg}COMPLETE!")
+  cli::cli_h2("{round_name} {conf_label}COMPLETE!")
 
   return(round_winners)
 }
@@ -92,10 +92,10 @@ play_round <- function(teams, nba_stats, round_name = NULL, seed = TRUE) {
 play_match <- function(matchup, nba_stats, round_name) {
   if (round_name == "Play off Finals") {
     conf <- NA
-    conf_msg <- ""
+    conf_label <- ""
   } else {
     conf <- unique(nba_stats[nba_stats$slug_team %in% matchup, ]$id_conference)
-    conf_msg <- paste0("(conf ", conf, ") ")
+    conf_label <- format_conf_label(conf)
   }
 
   # Create list of probabilities for sampling game length
@@ -115,7 +115,7 @@ play_match <- function(matchup, nba_stats, round_name) {
 
   # play game
   cli::cli_h3(
-    "Playing {round_name} {conf_msg}game: {.var {matchup[1]}} VS {.var {matchup[2]}}"
+    "Playing {round_name} {conf_label}game: {.var {matchup[1]}} VS {.var {matchup[2]}}"
   )
   cli::cli_alert_info("Game location: {.val {pid}} ({node})")
 
@@ -159,15 +159,18 @@ play_match <- function(matchup, nba_stats, round_name) {
 #' @return a character vector of team slugs of qualified teams.
 play_qualifiers <- function(teams) {
   conf <- unique(teams$id_conference)
+  conf_label <- format_conf_label(conf)
   # play season
   cli::cli_h2(
-    "Playing qualifiers for conference {.val {conf}} on {.var {Sys.getpid()}}"
+    "Playing qualifiers for {.val {conf_label}} conference on {.var {Sys.getpid()}}"
   )
   Sys.sleep(5)
   # sample qualifiers
   qualified <- sample(teams$slug_team, 8, prob = teams$prop_win)
 
-  cli::cli_alert_success("Conference {.val {conf}} qualifying round complete")
+  cli::cli_alert_success(
+    "{.val {conf_label}} conference qualifying round complete"
+  )
 
   return(qualified)
 }
@@ -189,6 +192,10 @@ compile_match_logs <- function(x) {
   })
   logs <- do.call(rbind, logs_list)
   logs[order(logs$date), ]
+}
+# Format conference ID as a display name string e.g. "(East) " or "(West) "
+format_conf_label <- function(conf) {
+  paste0("(", c("East", "West")[conf], ") ")
 }
 # Function replaces local IP addresses with fake IP address
 replace_ip <- function(hostname) {

--- a/nba/R/playoff-functions.R
+++ b/nba/R/playoff-functions.R
@@ -36,7 +36,8 @@ play_round <- function(teams, nba_stats, round_name = NULL, seed = TRUE) {
   if (is.null(round_name)) {
     round_id <- as.character(length(teams))
 
-    round_name <- switch(round_id,
+    round_name <- switch(
+      round_id,
       "8" = "Conference Round 1",
       "4" = "Conference Semi finals",
       "2" = "Conference finals"
@@ -46,7 +47,9 @@ play_round <- function(teams, nba_stats, round_name = NULL, seed = TRUE) {
     conf <- NA
     conf_msg <- ""
   } else {
-    conf <- unique(nba_stats[nba_stats$slug_team %in% unlist(teams), ]$id_conference)
+    conf <- unique(
+      nba_stats[nba_stats$slug_team %in% unlist(teams), ]$id_conference
+    )
     conf_msg <- paste0("(conf ", conf, ") ")
   }
   # Signal start of round
@@ -95,7 +98,6 @@ play_match <- function(matchup, nba_stats, round_name) {
     conf_msg <- paste0("(conf ", conf, ") ")
   }
 
-
   # Create list of probabilities for sampling game length
   probs <- list(
     c(0.9452, 0.0481, 0.0057, 6e-04, 4e-04),
@@ -112,13 +114,13 @@ play_match <- function(matchup, nba_stats, round_name) {
   node <- replace_ip(system2("hostname", stdout = TRUE))
 
   # play game
-  cli::cli_h3("Playing {round_name} {conf_msg}game: {.var {matchup[1]}} VS {.var {matchup[2]}}")
+  cli::cli_h3(
+    "Playing {round_name} {conf_msg}game: {.var {matchup[1]}} VS {.var {matchup[2]}}"
+  )
   cli::cli_alert_info("Game location: {.val {pid}} ({node})")
 
   # Sample game length
-  game_length <- sample(c(2.40, 2.65, 2.90, 3.15, 3.40), 1,
-    prob = prob
-  )
+  game_length <- sample(c(2.40, 2.65, 2.90, 3.15, 3.40), 1, prob = prob)
   # Send system to sleep to simulate playing match
   Sys.sleep(game_length)
 
@@ -128,9 +130,10 @@ play_match <- function(matchup, nba_stats, round_name) {
   # sample winner
   winner <- sample(match_df$slug_team, 1, prob = match_df$prop_win)
 
-
   # print messages
-  cli::cli_alert_info("{matchup[1]} VS {matchup[2]} match complete in {game_length * 50} minutes")
+  cli::cli_alert_info(
+    "{matchup[1]} VS {matchup[2]} match complete in {game_length * 50} minutes"
+  )
   cli::cli_alert_success("Winner: {winner}")
 
   # Compile match information into match logs data.frame and append as attribute.
@@ -157,7 +160,9 @@ play_match <- function(matchup, nba_stats, round_name) {
 play_qualifiers <- function(teams) {
   conf <- unique(teams$id_conference)
   # play season
-  cli::cli_h2("Playing qualifiers for conference {.val {conf}} on {.var {Sys.getpid()}}")
+  cli::cli_h2(
+    "Playing qualifiers for conference {.val {conf}} on {.var {Sys.getpid()}}"
+  )
   Sys.sleep(5)
   # sample qualifiers
   qualified <- sample(teams$slug_team, 8, prob = teams$prop_win)

--- a/nba/nba-playoffs.R
+++ b/nba/nba-playoffs.R
@@ -4,7 +4,8 @@ source(here::here("nba", "R", "playoff-functions.R"))
 # Load data ----
 nba_stats <- readr::read_csv(
   here::here(
-    "nba", "data",
+    "nba",
+    "data",
     "nba_stats_summaries_19-21.csv"
   )
 )
@@ -14,9 +15,7 @@ nba_stats <- readr::read_csv(
 tictoc::tic(msg = "Total Play-offs Duration")
 
 cli::cli_h1("Qualifiers have begun!")
-split_confs <- split(nba_stats,
-  f = nba_stats$id_conference
-)
+split_confs <- split(nba_stats, f = nba_stats$id_conference)
 set.seed(5, kind = "L'Ecuyer-CMRG")
 
 qualified_confs <- lapply(
@@ -41,7 +40,8 @@ cli::cli_h2("ALL Conference matches COMPLETE!")
 # Play Play-offs FINAL ----
 cli::cli_h1("Overall Playoff final has begun!")
 
-playoff_winner <- play_round(conf_winners,
+playoff_winner <- play_round(
+  conf_winners,
   nba_stats,
   round_name = "Play off Finals",
   seed = 7
@@ -50,12 +50,15 @@ playoff_winner <- play_round(conf_winners,
 # Announce Winner!
 winner_stats <- nba_stats[nba_stats$slug_team == playoff_winner, ]
 cli::cli_h1("Playoffs complete!")
-cli::cli_alert_success("Winner: {.field {winner_stats$name_team}} ({winner_stats$slug_team})")
+cli::cli_alert_success(
+  "Winner: {.field {winner_stats$name_team}} ({winner_stats$slug_team})"
+)
 tictoc::toc()
 
 # Write match logs to csv ----
 fs::dir_create(here::here("nba", "outputs"))
-write.csv(attr(playoff_winner, "match_logs"),
+write.csv(
+  attr(playoff_winner, "match_logs"),
   file = here::here("nba", "outputs", "playoff_results.csv"),
   row.names = FALSE
 )

--- a/nba/slurm/nba-playoffs.slurm
+++ b/nba/slurm/nba-playoffs.slurm
@@ -13,7 +13,7 @@
 # send mail to this address
 #SBATCH --mail-user=youremail@here.com
 
-module load R/4.4.0-gcc8
+module load R/4.5.3-gcc8
 module load openmpi/5.0.9_gcc15
 
 cd parallel-r-materials/


### PR DESCRIPTION
## Summary
- Upgrade R module from 4.4.0 to 4.5.3 in all SLURM scripts
- Add `format_conf_label()` helper to convert conference IDs to display names (East/West)
- Rename `conf_msg` to `conf_label` and use `format_conf_label()` throughout playoff functions
- Code formatting with air

## Test plan
- [ ] Verify SLURM scripts load correct R module version
- [ ] Run NBA playoff simulation to confirm conference labels display correctly